### PR TITLE
issue #127

### DIFF
--- a/src/toolbarActions/toolbarFunctions.js
+++ b/src/toolbarActions/toolbarFunctions.js
@@ -90,7 +90,7 @@ async function saveGraphMLFile(state) {
             await stream.write(getGraphFun(state).saveToFolder());
             await stream.close();
             toast.success('File saved Successfully');
-        } else if (graph.fileHandle === null) {
+        } else if (!graph.fileHandle) {
             getGraphFun(state).saveWithoutFileHandle();
         } else {
             toast.info('Switch to Edge/Chrome!');


### PR DESCRIPTION
issue #127 

Reason:

In the save function , when the browser is reloaded there is no fileHandler so it should go to 2nd else if which is `saveWithoutFileHandle` 

but `graph.fileHandle` is `undefined` which compared to null rather should be comapred to undefined