### PR TITLE
reset Zoom

### DIFF
--- a/src/graph-builder/graph-core/2-canvas.js
+++ b/src/graph-builder/graph-core/2-canvas.js
@@ -7,6 +7,7 @@ class GraphCanvas extends Core {
 
     resetZoom() {
         this.cy.reset();
+        this.cy.center();
     }
 
     setOnZoom(cb) {


### PR DESCRIPTION
issue #149 

Hi @pradeeban ,

Description:
Left-most button: It reset the zoom level to default [refer](https://js.cytoscape.org/#cy.reset) 
Middle square button: It zooms the graph to fit in the window like this
![image](https://user-images.githubusercontent.com/100110395/230753572-40967c3f-e2f2-4c74-8a5c-7158e98459d1.png)

The thing we can do is that after resetting the left-most button we can center the graph so that it will be symmetrically aligned on resetting the zoom

if the graph is too large it may go out of the window but centered. As fitting the graph properly is the work of a squared button so this is what max can be expected from the left-most button that It should reset and center the graph

I would like to hear any suggestion on this from you and other contributors