### PR TITLE
Integrated Monaco Code Editor, removed unwanted upper save and save as buttons, as now only editor window scrolls not the whole screen.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "homepage": "https://controlcore-project.github.io/concore-editor",
   "dependencies": {
+    "@monaco-editor/react": "^4.4.5",
     "@szhsin/react-menu": "^1.10.0",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
@@ -20,7 +21,7 @@
     "konva": "^7.0.3",
     "md5": "^2.3.0",
     "moment": "^2.29.4",
-    "prismjs": "^1.29.0",
+    "prismjs": "^1.30.0",
     "rc-slider": "^9.7.2",
     "rc-switch": "^3.2.2",
     "react": "^17.0.2",


### PR DESCRIPTION
Completed Issue #192 ,

Below is an attached image of the integrated Monaco code editor. It closely resembles the theme of the Concore editor and offers a better coding experience than conventional code editors. Additionally, I have removed the upper unnecessary “Save” and “Save As” buttons for a cleaner interface as now only editor windows scrolls not the whole window.

<img width="1440" alt="Screenshot 2025-03-22 at 12 33 53 AM" src="https://github.com/user-attachments/assets/2a12a691-d7fe-4570-926f-6f907531a109" />
