### PR TITLE
Fixed ESLint Error because of empty accessible text in label

### DIFF
--- a/src/component/modals/OptionsModal.jsx
+++ b/src/component/modals/OptionsModal.jsx
@@ -75,8 +75,8 @@ const OptionsModal = ({ superState, dispatcher }) => {
                 </label>
                 <br />
                 <br />
-                <span>Library Path:&nbsp;&nbsp;</span>
                 <label htmlFor="librarypath">
+                    Library Path:&nbsp;&nbsp;
                     <input
                         size="59"
                         type="text"


### PR DESCRIPTION
Fixed Issue #209 , The label tag in the OptionsModal.jsx file does not have accessible text, causing an ESLint error (jsx-a11y/label-has-associated-control).
