### PR TITLE
Added FullScreen Functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "hotkeys-js": "^3.8.7",
         "jquery": "^3.0.0",
         "konva": "^7.0.3",
+        "lucide-react": "^0.487.0",
         "md5": "^2.3.0",
         "moment": "^2.29.4",
         "prismjs": "^1.30.0",
@@ -14994,6 +14995,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.487.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.487.0.tgz",
+      "integrity": "sha512-aKqhOQ+YmFnwq8dWgGjOuLc8V1R9/c/yOd+zDY4+ohsR2Jo05lSGc3WsstYPIzcTpeosN7LoCkLReUUITvaIvw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "hotkeys-js": "^3.8.7",
     "jquery": "^3.0.0",
     "konva": "^7.0.3",
+    "lucide-react": "^0.487.0",
     "md5": "^2.3.0",
     "moment": "^2.29.4",
     "prismjs": "^1.30.0",

--- a/src/component/FullScreenButton.jsx
+++ b/src/component/FullScreenButton.jsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+import { Maximize, Minimize } from 'lucide-react';
+
+export default function FullScreenButton() {
+    const [isFullscreen, setIsFullscreen] = useState(false);
+
+    const toggleFullscreen = () => {
+        if (!document.fullscreenElement) {
+            document.documentElement.requestFullscreen();
+            setIsFullscreen(true);
+        } else {
+            document.exitFullscreen();
+            setIsFullscreen(false);
+        }
+    };
+
+    return (
+        <button type="button" onClick={toggleFullscreen}>
+            {isFullscreen ? <Minimize size={20} /> : <Maximize size={20} />}
+        </button>
+    );
+}

--- a/src/component/Header.jsx
+++ b/src/component/Header.jsx
@@ -8,6 +8,7 @@ import {
     ActionButton, Vsep, Hsep, Space, TextBox, Switcher, DropDown, FileUploader,
 } from './HeaderComps';
 import 'rc-switch/assets/index.css';
+import FullScreenButton from './FullScreenButton';
 // import ServerActions from './serverActions/ServerActions';
 
 const setHotKeys = (actions) => {
@@ -38,13 +39,15 @@ const Header = ({ superState, dispatcher }) => {
 
     return (
         <header className="header">
-            <section className="middle titlebar">
-                {
-                    superState.curGraphInstance ? `${
-                        superState.curGraphInstance.projectName
-                    } - concore Editor` : 'untitled'
-                }
-            </section>
+            <div style={{ display: 'flex' }}>
+                <section className="middle titlebar">
+                    {
+                        superState.curGraphInstance ? `${superState.curGraphInstance.projectName
+                        } - concore Editor` : 'untitled'
+                    }
+                </section>
+                <FullScreenButton />
+            </div>
             <section className="toolbar">
                 {
                     actions.map(({
@@ -67,7 +70,7 @@ const Header = ({ superState, dispatcher }) => {
                         case 'menu': return <DropDown {...props} />;
                         case 'file-upload': return <FileUploader {...props} superState={superState} />;
                         case 'action': return <ActionButton {...props} />;
-                        // case 'serverActions': return <ServerActions superState={superState} />;
+                            // case 'serverActions': return <ServerActions superState={superState} />;
                         default: return <></>;
                         }
                     })


### PR DESCRIPTION
Added Feature #230 

The full-screen button, following the same design scheme as concore-editor, has been positioned in the top right corner to avoid overlapping with the study toolbar.


<img width="1440" alt="Screenshot 2025-04-04 at 6 52 32 PM" src="https://github.com/user-attachments/assets/d8145162-fd33-4249-95b1-abf6d4428ef3" />
