### PR TITLE
fix: edges with same prefix(integer) allowed

### DIFF
--- a/src/config/defaultValidators.js
+++ b/src/config/defaultValidators.js
@@ -35,21 +35,21 @@ edges.forEach((e) => {
             err: 'Edge with same label exists.',
         };
     }
-    let numE = "";
-    for (let char of e.label) {
-        if (!isNaN(parseInt(char))) {
-        numE += char;
-        } else if (numE !== "") {
-        break;
-        }
-    }
-    if (numE === numEdge && numE != "0" && numE !== "") {
-        message = {
-            ok: false,
-            err: '2 edges cannot have same prefixes if they are number',
-        };
-        return message;
-    }
+    // let numE = "";
+    // for (let char of e.label) {
+    //     if (!isNaN(parseInt(char))) {
+    //     numE += char;
+    //     } else if (numE !== "") {
+    //     break;
+    //     }
+    // }
+    // if (numE === numEdge && numE != "0" && numE !== "") {
+    //     message = {
+    //         ok: false,
+    //         err: '2 edges cannot have same prefixes if they are number',
+    //     };
+    //     return message;
+    // }
 });
 return message;
 }`;


### PR DESCRIPTION
Made changes in default validator to remove the logic which didn't allow having any two edges with same prefix (integer) as their name.

Before:
<img width="949" height="479" alt="image" src="https://github.com/user-attachments/assets/8ff75576-8251-4fc5-8e37-784a8dbf24a5" />
<img width="942" height="513" alt="image" src="https://github.com/user-attachments/assets/68c2566a-e1c6-401a-9bfd-2588e2c2d636" />

After:
<img width="973" height="483" alt="image" src="https://github.com/user-attachments/assets/a152ca3a-eedb-43cf-a618-514b21b3e714" />
<img width="777" height="300" alt="image" src="https://github.com/user-attachments/assets/e2e9ff91-28f2-4a4a-9ff7-ad38e66cfa74" />
