### PR TITLE
Dev

### DIFF
--- a/src/config/cytoscape-style.js
+++ b/src/config/cytoscape-style.js
@@ -23,7 +23,7 @@ const style = [
                 const w = ele.data('style').width;
                 const h = ele.data('style').height;
                 const val = Math.min(w, h);
-                if (val < 20) return 10;
+                if (val < 20) return 5;
                 if (val > 500) return 60;
                 return 10 + ((val - 20) * 50) / 480;
             },


### PR DESCRIPTION
Initially:
<img width="876" height="411" alt="image" src="https://github.com/user-attachments/assets/f2d7f0e6-7f14-4703-a2dd-c8ba1e472955" />


On increasing size of node 1 (notice the font size scales up):
<img width="1089" height="615" alt="image" src="https://github.com/user-attachments/assets/6e27d9e8-5d86-40f1-89d3-7d37d7125a0d" />



on decreasing size of node 1 (horizontal overflowing prevented):
<img width="1043" height="518" alt="image" src="https://github.com/user-attachments/assets/adec932e-1a7c-4fec-88f2-24ae8c1205d7" />
