### PR TITLE
fix: Abort error in Open, Save, Save as on pressing cancel button or not selecting a file

### DIFF
--- a/src/component/fileBrowser.jsx
+++ b/src/component/fileBrowser.jsx
@@ -121,9 +121,15 @@ const LocalFileBrowser = ({ superState, dispatcher }) => {
             multiple: false,
         };
 
-        const [fileHandle] = await window.showOpenFilePicker(pickerOpts);
-        const fileObj = await fileHandle.getFile();
-        readFile(superState, dispatcher, fileObj, fileHandle);
+        try {
+            const [fileHandle] = await window.showOpenFilePicker(pickerOpts);
+            const fileObj = await fileHandle.getFile();
+            readFile(superState, dispatcher, fileObj, fileHandle);
+        } catch (error) {
+            if (error.name !== 'AbortError') {
+                console.error(error);
+            }
+        }
     };
 
     return (

--- a/src/component/modals/FileEdit.jsx
+++ b/src/component/modals/FileEdit.jsx
@@ -39,20 +39,26 @@ const FileEditModal = ({ superState, dispatcher }) => {
     }
 
     async function saveAsSubmit() {
-        const handle = await window.showSaveFilePicker();
-        const stream = await handle.createWritable();
-        await stream.write(codeStuff);
-        await stream.close();
-        const fileData = await handle.getFile();
-        let fS = superState.fileState;
-        fS = fS.concat([{
-            key: `${superState.uploadedDirName}/${handle.name}`,
-            modified: fileData.lastModified,
-            size: fileData.size,
-            fileObj: fileData,
-            fileHandle: handle,
-        }]);
-        dispatcher({ type: T.SET_FILE_STATE, payload: fS });
+        try {
+            const handle = await window.showSaveFilePicker();
+            const stream = await handle.createWritable();
+            await stream.write(codeStuff);
+            await stream.close();
+            const fileData = await handle.getFile();
+            let fS = superState.fileState;
+            fS = fS.concat([{
+                key: `${superState.uploadedDirName}/${handle.name}`,
+                modified: fileData.lastModified,
+                size: fileData.size,
+                fileObj: fileData,
+                fileHandle: handle,
+            }]);
+            dispatcher({ type: T.SET_FILE_STATE, payload: fS });
+        } catch (error) {
+            if (error.name !== 'AbortError') {
+                console.error(error);
+            }
+        }
     }
 
     function handleSaveAsClick() {

--- a/src/graph-builder/graph-core/5-load-save.js
+++ b/src/graph-builder/graph-core/5-load-save.js
@@ -117,26 +117,33 @@ class GraphLoadSave extends GraphUndoRedo {
                     },
                 ],
             };
-            const handle = await window.showSaveFilePicker(options);
-            const stream = await handle.createWritable();
-            await stream.write(blob);
-            await stream.close();
-            const fileData = await handle.getFile();
-            let fS = this.superState.fileState;
-            fS = fS.concat([{
-                key: `${this.superState.uploadedDirName}/${handle.name}`,
-                modified: fileData.lastModified,
-                size: fileData.size,
-                fileObj: fileData,
-                fileHandle: handle,
-            }]);
-            this.dispatcher({ type: T.SET_FILE_STATE, payload: fS });
+            try {
+                const handle = await window.showSaveFilePicker(options);
+                const stream = await handle.createWritable();
+                await stream.write(blob);
+                await stream.close();
+                const fileData = await handle.getFile();
+                let fS = this.superState.fileState;
+                fS = fS.concat([{
+                    key: `${this.superState.uploadedDirName}/${handle.name}`,
+                    modified: fileData.lastModified,
+                    size: fileData.size,
+                    fileObj: fileData,
+                    fileHandle: handle,
+                }]);
+                this.dispatcher({ type: T.SET_FILE_STATE, payload: fS });
+                toast.success('File saved Successfully');
+            } catch (error) {
+                if (error.name !== 'AbortError') {
+                    console.error(error);
+                }
+            }
         } else {
             // eslint-disable-next-line no-alert
             const fileName = prompt('Filename:');
             saveAs(blob, `${fileName || `${this.getName()}-concore`}.graphml`);
+            toast.success('File saved Successfully');
         }
-        toast.success('File saved Successfully');
     }
 
     async saveWithoutFileHandle() {
@@ -158,15 +165,21 @@ class GraphLoadSave extends GraphUndoRedo {
                 },
             ],
         };
-        const handle = await window.showSaveFilePicker(options);
-        this.dispatcher({
-            type: T.SET_FILE_HANDLE,
-            payload: { curGraphIndex: this.superState.curGraphIndex, fileHandle: handle },
-        });
-        const stream = await handle.createWritable();
-        await stream.write(blob);
-        await stream.close();
-        toast.success('File saved Successfully');
+        try {
+            const handle = await window.showSaveFilePicker(options);
+            this.dispatcher({
+                type: T.SET_FILE_HANDLE,
+                payload: { curGraphIndex: this.superState.curGraphIndex, fileHandle: handle },
+            });
+            const stream = await handle.createWritable();
+            await stream.write(blob);
+            await stream.close();
+            toast.success('File saved Successfully');
+        } catch (error) {
+            if (error.name !== 'AbortError') {
+                console.error(error);
+            }
+        }
     }
 
     saveToFolder() {


### PR DESCRIPTION
There were Abort Errors (runtime errors) on pressing the cancel button or not selecting a file from "OPEN" , "SAVE", "SAVE AS".
I seems the errors were thrown because the logic when someone doesn't actually open/save file wasn't considered.
I have fixed this by using try/catch FileEdit.jsx , FileBrowser.jsx, 5-load-save.js