### PR TITLE
Fix: two node with same lable in first half possible

### DIFF
--- a/src/config/defaultValidators.js
+++ b/src/config/defaultValidators.js
@@ -1,5 +1,5 @@
 const nodeValidator = `(node, nodes, edges) => {
-    var regex = /^[A-za-z0-9]+[:[A-Za-z0-9.]+]|[^$]$/;
+    var regex = /^[A-Za-z0-9]+[:[A-Za-z0-9.]+]|[^$]$/;
     let message = { ok: true, err: null };
     if (!regex.test(node.label)) {
         message = {
@@ -9,7 +9,7 @@ const nodeValidator = `(node, nodes, edges) => {
         return message;
     }
     nodes.forEach((n) => {
-        if (n.id !== node.id && n.label.split(':')[0] === node.label.split(':')[0]) {
+        if (n.id !== node.id && n.label === node.label) {
             message = {
                 ok: false,
                 err: 'Node with same label exists.',


### PR DESCRIPTION
@pradeeban I have fixed the issue, 
<img width="638" height="293" alt="image" src="https://github.com/user-attachments/assets/17621b44-1b13-4117-9a53-59a41bd47720" />

Also, I noticed, there was a small problem in the regex, I have fixed that too.
Everything should be fine, Thanks!
This fixes #285.