### PR TITLE
refactor: use environment config for execution engine URL

### DIFF
--- a/src/component/modals/ContributeDetails.jsx
+++ b/src/component/modals/ContributeDetails.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { toast } from 'react-toastify';
 import axios from 'axios';
+import { EXECUTION_ENGINE_URL } from '../../serverCon/config';
 import Modal from './ParentModal';
 import { actionType as T } from '../../reducer';
 import './contributeDetails.css';
@@ -24,7 +25,7 @@ const ContributeDetails = ({ superState, dispatcher }) => {
         const id = toast.loading('Processing your Request.Please wait...');
         try {
             e.preventDefault();
-            const result = await axios.post('http://127.0.0.1:5000/contribute', {
+            const result = await axios.post(`${EXECUTION_ENGINE_URL}/contribute`, {
                 study,
                 auth,
                 desc,

--- a/src/graph-builder/graph-core/6-server.js
+++ b/src/graph-builder/graph-core/6-server.js
@@ -1,6 +1,7 @@
 import { toast } from 'react-toastify';
 import Axios from 'axios';
 import { actionType as T } from '../../reducer';
+import { EXECUTION_ENGINE_URL } from '../../serverCon/config';
 import GraphLoadSave from './5-load-save';
 // import {
 //     postGraph, updateGraph, forceUpdateGraph, getGraph, getGraphWithHashCheck,
@@ -73,7 +74,7 @@ class GraphServer extends GraphLoadSave {
             autoClose: false,
         });
         this.dispatcher({ type: T.SET_LOGS, payload: false });
-        Axios.post(`http://127.0.0.1:5000/build/${this.superState.uploadedDirName}?fetch=${this.superState.graphs[this.superState.curGraphIndex].fileName.split('.')[0]}&unlock=${this.superState.unlockCheck}&docker=${this.superState.dockerCheck}&maxtime=${this.superState.maxTime}&params=${this.superState.params}&octave=${this.superState.octave}`)
+        Axios.post(`${EXECUTION_ENGINE_URL}/build/${this.superState.uploadedDirName}?fetch=${this.superState.graphs[this.superState.curGraphIndex].fileName.split('.')[0]}&unlock=${this.superState.unlockCheck}&docker=${this.superState.dockerCheck}&maxtime=${this.superState.maxTime}&params=${this.superState.params}&octave=${this.superState.octave}`)
             .then((res) => { // eslint-disable-next-line
                 toast.success(res.data['message']);
                 this.dispatcher({
@@ -98,7 +99,7 @@ class GraphServer extends GraphLoadSave {
             autoClose: false,
         });
         this.dispatcher({ type: T.SET_LOGS, payload: false });
-        Axios.post(`http://127.0.0.1:5000/debug/${this.superState.graphs[this.superState.curGraphIndex].fileName.split('.')[0]}`)
+        Axios.post(`${EXECUTION_ENGINE_URL}/debug/${this.superState.graphs[this.superState.curGraphIndex].fileName.split('.')[0]}`)
             .then((res) => { // eslint-disable-next-line
                 toast.success(res.data['message'])
                 this.dispatcher({
@@ -122,7 +123,7 @@ class GraphServer extends GraphLoadSave {
             autoClose: false,
         });
         this.dispatcher({ type: T.SET_LOGS, payload: false });
-        Axios.post(`http://127.0.0.1:5000/run/${this.superState.graphs[this.superState.curGraphIndex].fileName.split('.')[0]}`)
+        Axios.post(`${EXECUTION_ENGINE_URL}/run/${this.superState.graphs[this.superState.curGraphIndex].fileName.split('.')[0]}`)
             .then((res) => { // eslint-disable-next-line
                 toast.success(res.data['message'])
                 this.dispatcher({
@@ -146,7 +147,7 @@ class GraphServer extends GraphLoadSave {
             autoClose: false,
         });
         this.dispatcher({ type: T.SET_LOGS, payload: false });
-        Axios.post(`http://127.0.0.1:5000/clear/${this.superState.graphs[this.superState.curGraphIndex].fileName.split('.')[0]}
+        Axios.post(`${EXECUTION_ENGINE_URL}/clear/${this.superState.graphs[this.superState.curGraphIndex].fileName.split('.')[0]}
         ?unlock=${this.superState.unlockCheck}&maxtime=${this.superState.maxTime}&params=${this.superState.params}`)
             .then((res) => { // eslint-disable-next-line
                 toast.success(res.data['message']);
@@ -171,7 +172,7 @@ class GraphServer extends GraphLoadSave {
             autoClose: false,
         });
         this.dispatcher({ type: T.SET_LOGS, payload: false });
-        Axios.post(`http://127.0.0.1:5000/stop/${this.superState.graphs[this.superState.curGraphIndex].fileName.split('.')[0]}`)
+        Axios.post(`${EXECUTION_ENGINE_URL}/stop/${this.superState.graphs[this.superState.curGraphIndex].fileName.split('.')[0]}`)
             .then((res) => { // eslint-disable-next-line
                 toast.success(res.data['message'])
                 this.dispatcher({
@@ -195,7 +196,7 @@ class GraphServer extends GraphLoadSave {
             autoClose: false,
         });
         this.dispatcher({ type: T.SET_LOGS, payload: false });
-        Axios.delete(`http://127.0.0.1:5000/destroy/${this.superState.graphs[this.superState.curGraphIndex].fileName.split('.')[0]}`)
+        Axios.delete(`${EXECUTION_ENGINE_URL}/destroy/${this.superState.graphs[this.superState.curGraphIndex].fileName.split('.')[0]}`)
             .then((res) => { // eslint-disable-next-line
                 toast.success(res.data['message'])
                 this.dispatcher({
@@ -219,7 +220,7 @@ class GraphServer extends GraphLoadSave {
             autoClose: false,
         });
         // this.dispatcher({ type: T.SET_LOGS, payload: false });
-        Axios.post(`http://127.0.0.1:5000/library/${this.superState.uploadedDirName}?filename=${fileName}&path=${this.superState.library}`)
+        Axios.post(`${EXECUTION_ENGINE_URL}/library/${this.superState.uploadedDirName}?filename=${fileName}&path=${this.superState.library}`)
             .then((res) => { // eslint-disable-next-line
                 toast.info(res.data['message'])
                 toast.dismiss(toastId);

--- a/src/serverCon/config.js
+++ b/src/serverCon/config.js
@@ -1,3 +1,5 @@
+export const EXECUTION_ENGINE_URL = process.env.REACT_APP_EXECUTION_ENGINE_URL || 'http://127.0.0.1:5000';
+
 export default {
     baseURL: 'http://localhost:8000/',
     getGraph: (id) => `workflow/${id}`,


### PR DESCRIPTION
Changes:

Added [EXECUTION_ENGINE_URL](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) constant to [config.js](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) using [process.env.REACT_APP_EXECUTION_ENGINE_URL](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with fallback to http://127.0.0.1:5000

Replaced 7 hardcoded URLs in [6-server.js](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Replaced 1 hardcoded URL in [ContributeDetails.jsx](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Fixes #277