### PR TITLE
fix: improve error messages from server actions

### DIFF
--- a/src/graph-builder/graph-core/6-server.js
+++ b/src/graph-builder/graph-core/6-server.js
@@ -85,7 +85,7 @@ class GraphServer extends GraphLoadSave {
                 this.dispatcher({ type: T.SET_LOGS_MESSAGE, payload: this.superState.logsmessage + res.data.output });
                 toast.dismiss(toastId);
             }).catch((err) => { // eslint-disable-next-line
-                toast.error(err.message);
+                toast.error(err.response?.data?.message || err.message);
                 toast.dismiss(toastId);
             });
         if (this.serverID);
@@ -109,7 +109,7 @@ class GraphServer extends GraphLoadSave {
                 });
                 toast.dismiss(toastId);
             }).catch((err) => { // eslint-disable-next-line
-                toast.error(err.message);
+                toast.error(err.response?.data?.message || err.message);
                 toast.dismiss(toastId);
             });
         if (this.serverID);
@@ -133,7 +133,7 @@ class GraphServer extends GraphLoadSave {
                 });
                 toast.dismiss(toastId);
             }).catch((err) => { // eslint-disable-next-line
-                toast.error(err.message);
+                toast.error(err.response?.data?.message || err.message);
                 toast.dismiss(toastId);
             });
         if (this.serverID);
@@ -158,7 +158,7 @@ class GraphServer extends GraphLoadSave {
                 });
                 toast.dismiss(toastId);
             }).catch((err) => { // eslint-disable-next-line
-                toast.error(err.message);
+                toast.error(err.response?.data?.message || err.message);
                 toast.dismiss(toastId);
             });
         if (this.serverID);
@@ -182,7 +182,7 @@ class GraphServer extends GraphLoadSave {
                 });
                 toast.dismiss(toastId);
             }).catch((err) => { // eslint-disable-next-line
-                toast.error(err.message);
+                toast.error(err.response?.data?.message || err.message);
                 toast.dismiss(toastId);
             });
         if (this.serverID);
@@ -206,7 +206,7 @@ class GraphServer extends GraphLoadSave {
                 });
                 toast.dismiss(toastId);
             }).catch((err) => { // eslint-disable-next-line
-                toast.error(err.message);
+                toast.error(err.response?.data?.message || err.message);
                 toast.dismiss(toastId);
             });
         if (this.serverID);
@@ -224,7 +224,7 @@ class GraphServer extends GraphLoadSave {
                 toast.info(res.data['message'])
                 toast.dismiss(toastId);
             }).catch((err) => { // eslint-disable-next-line
-                toast.error(err.message);
+                toast.error(err.response?.data?.message || err.message);
                 toast.dismiss(toastId);
             });
         if (this.serverID);


### PR DESCRIPTION
Updated all 7 catch blocks in server actions (build, debug, run, clear, stop, destroy, library) to check for backend error messages before falling back to generic [err.message](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Now when the backend returns something useful like "Invalid workflow file" or "Permission denied", users see the actual error instead of "Request failed with status code 500".

Fixes #292