### PR TITLE
fix edge validation source id

### DIFF
--- a/src/graph-builder/graph-core/3-component.js
+++ b/src/graph-builder/graph-core/3-component.js
@@ -124,7 +124,7 @@ class GraphComponent extends GraphCanvas {
             type: T.Model_Open_Create_Edge,
             cb: (edgeLabel, edgeStyle) => {
                 const message = this.validiateEdge(edgeLabel, edgeStyle,
-                    edgeData.targetID, edgeData.targetID, null, 'New');
+                    edgeData.sourceID, edgeData.targetID, null, 'New');
                 if (message.ok) this.addEdgeWithLabel({ ...edgeData, type: edgeData.type || 'ordin' }, tid);
                 return message;
             },


### PR DESCRIPTION
Fixed [addEdge](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to pass the real [sourceID](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) into [validiateEdge](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (it was sending [targetID](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for both)

fixes #296