### PR TITLE
fix node label regex

### DIFF
--- a/src/config/defaultValidators.js
+++ b/src/config/defaultValidators.js
@@ -1,5 +1,5 @@
 const nodeValidator = `(node, nodes, edges) => {
-    var regex = /^[A-Za-z0-9]+[:[A-Za-z0-9.]+]|[^$]$/;
+    var regex = /^[A-Za-z0-9]+(:[A-Za-z0-9_]+)*$/;
     let message = { ok: true, err: null };
     if (!regex.test(node.label)) {
         message = {


### PR DESCRIPTION
fixes #308

regex was matching everything, now properly validates node labels