### PR TITLE
feat: restore server sync push/pull methods

### DIFF
--- a/src/graph-builder/graph-core/6-server.js
+++ b/src/graph-builder/graph-core/6-server.js
@@ -6,6 +6,9 @@ import GraphLoadSave from './5-load-save';
 // import {
 //     postGraph, updateGraph, forceUpdateGraph, getGraph, getGraphWithHashCheck,
 // } from '../../serverCon/crud_http';
+import {
+    postGraph, updateGraph, forceUpdateGraph, getGraph, getGraphWithHashCheck,
+} from '../../serverCon/crud_http';
 
 class GraphServer extends GraphLoadSave {
     set(config) {
@@ -66,6 +69,74 @@ class GraphServer extends GraphLoadSave {
     //         toast.success('Not on server');
     //     }
     // }
+
+    pushToServer() {
+        if (this.serverID) {
+            updateGraph(this.serverID, this.getGraphML()).then(() => {
+
+            }).catch((err) => {
+                toast.error(err.response?.data?.message || err.message);
+            });
+        } else {
+            postGraph(this.getGraphML()).then((serverID) => {
+                this.set({ serverID });
+                this.cy.emit('graph-modified');
+            }).catch((err) => {
+                toast.error(err.response?.data?.message || err.message);
+            });
+        }
+    }
+
+    forcePushToServer() {
+        // eslint-disable-next-line
+        if (!window.confirm(
+            'Forced push may result in workflow overwite and loss of changes pushed by others. Confirm?',
+        )) return;
+        if (this.serverID) {
+            forceUpdateGraph(this.serverID, this.getGraphML()).then(() => {
+
+            }).catch((err) => {
+                toast.error(err.response?.data?.message || err.message);
+            });
+        } else {
+            postGraph(this.getGraphML()).then((serverID) => {
+                this.set({ serverID });
+            }).catch((err) => {
+                toast.error(err.response?.data?.message || err.message);
+            });
+        }
+    }
+
+    forcePullFromServer() {
+        // eslint-disable-next-line
+        if (!window.confirm(
+            'Forced pull may result in workflow overwite and loss of unsaved changes. Confirm?',
+        )) return;
+        if (this.serverID) {
+            getGraph(this.serverID).then((graphXML) => {
+                this.setGraphML(graphXML);
+            }).catch((err) => {
+                toast.error(err.response?.data?.message || err.message);
+            });
+        } else {
+            // eslint-disable-next-line no-toast.success
+            toast.success('Not on server');
+        }
+    }
+
+    pullFromServer() {
+        if (this.actionArr.length === 0) { this.forcePullFromServer(); return; }
+        if (this.serverID) {
+            getGraphWithHashCheck(this.serverID, this.actionArr.at(-1).hash).then((graphXML) => {
+                this.setGraphML(graphXML);
+            }).catch(() => {
+
+            });
+        } else {
+            // eslint-disable-next-line no-toast.success
+            toast.success('Not on server');
+        }
+    }
 
     serverAction(method, url, successPayload, onSuccess) {
         const toastId = toast.info('LOADING.......', {


### PR DESCRIPTION

uncommented and wired up [pushToServer](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [forcePushToServer](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [pullFromServer](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [forcePullFromServer](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) ... they were already written and the backend ([crud_http.js](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), Flask routes, MongoDB model) is all still there. Added [.catch](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) error handling and [window.confirm](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) guards for force operations based on the DHGWorkflow original. 

Needs testing against a running server instance, flagging that upfront

fixes #314