### PR TITLE
fix: allow dot in node labels after colon

### DIFF
--- a/src/config/defaultValidators.js
+++ b/src/config/defaultValidators.js
@@ -1,5 +1,5 @@
 const nodeValidator = `(node, nodes, edges) => {
-    var regex = /^[A-Za-z0-9]+(:[A-Za-z0-9_]+)*$/;
+    var regex = /^[A-Za-z0-9]+(:[A-Za-z0-9_.]+)*$/;
     let message = { ok: true, err: null };
     if (!regex.test(node.label)) {
         message = {


### PR DESCRIPTION
Added . back to the character class: [A-Za-z0-9_.]

fixed #318