### PR TITLE
refactor: use serverAction helper in library() method

### DIFF
--- a/src/graph-builder/graph-core/6-server.js
+++ b/src/graph-builder/graph-core/6-server.js
@@ -223,21 +223,9 @@ class GraphServer extends GraphLoadSave {
     }
 
     library(fileName) {
-        const toastId = toast.info('LOADING.......', {
-            position: 'bottom-left',
-            autoClose: false,
-        });
-        // this.dispatcher({ type: T.SET_LOGS, payload: false });
         const url = `${EXECUTION_ENGINE_URL}/library/${this.superState.uploadedDirName}`
             + `?filename=${fileName}&path=${this.superState.library}`;
-        Axios.post(url)
-            .then((res) => { // eslint-disable-next-line
-                toast.info(res.data['message'])
-                toast.dismiss(toastId);
-            }).catch((err) => { // eslint-disable-next-line
-                toast.error(err.response?.data?.message || err.message);
-                toast.dismiss(toastId);
-            });
+        this.serverAction('post', url, null);
     }
 
     setCurStatus() {


### PR DESCRIPTION
[library() was doing its own toast + axios dance instead of using the serverAction() helper that every other server method uses fixes #321](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)