### PR TITLE
Fix missing workflow 404 handling and add regression tests

### DIFF
--- a/server/controller/workflow.py
+++ b/server/controller/workflow.py
@@ -1,9 +1,16 @@
-from model.workflows import *
+from model.workflows import WorkFlowModel
 from flask import request, make_response, Blueprint
 import defusedxml.ElementTree as ET
 
 workFlow = Blueprint('workflow', __name__)
 workFlowModel = WorkFlowModel()
+
+
+def isMissingWorkflow(graphml):
+    if graphml is None:
+        return True
+    # Backward-compatible guard for legacy model return type.
+    return isinstance(graphml, tuple) and len(graphml) > 0 and graphml[0] is False
 
 
 def getLasteshActionHash(root):
@@ -32,7 +39,7 @@ def postWorkflow():
 @workFlow.route("/<serverID>")
 def getWorkflow(serverID):
     graphml = workFlowModel.get(serverID)
-    if graphml is None:
+    if isMissingWorkflow(graphml):
         return "Not Found", 404
     if('X-Latest-Hash' in request.headers):
         latestHash = request.headers['X-Latest-Hash']

--- a/server/model/workflows.py
+++ b/server/model/workflows.py
@@ -32,7 +32,7 @@ class WorkFlowModel:
     def get(self, serverID):
         cl = self.collection.find_one({'serverID': serverID})
         if not cl:
-            return False, 'Record Not Found'
+            return None
         return cl['graphml']
 
     def update(self, serverID, graphml, latestHash, allHash):

--- a/server/tests/test_workflow_controller.py
+++ b/server/tests/test_workflow_controller.py
@@ -1,0 +1,82 @@
+import importlib
+import pathlib
+import sys
+import types
+import unittest
+
+from flask import Flask
+
+VALID_GRAPHML = (
+    '<graphml xmlns="http://graphml.graphdrawing.org/xmlns">'
+    '<graph edgedefault="directed">'
+    '<actionHistory><hash>hash-1</hash></actionHistory>'
+    '</graph>'
+    '</graphml>'
+)
+
+
+class FakeWorkFlowModel:
+    def __init__(self, graph_response):
+        self.graph_response = graph_response
+
+    def get(self, _server_id):
+        return self.graph_response
+
+
+class WorkflowControllerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        server_root = pathlib.Path(__file__).resolve().parents[1]
+        if str(server_root) not in sys.path:
+            sys.path.insert(0, str(server_root))
+
+        fake_model_pkg = types.ModuleType('model')
+        fake_model_workflows = types.ModuleType('model.workflows')
+
+        class StubWorkFlowModel:
+            def get(self, _server_id):
+                return None
+
+        fake_model_workflows.WorkFlowModel = StubWorkFlowModel
+        fake_model_pkg.workflows = fake_model_workflows
+
+        sys.modules['model'] = fake_model_pkg
+        sys.modules['model.workflows'] = fake_model_workflows
+
+        if 'controller.workflow' in sys.modules:
+            del sys.modules['controller.workflow']
+        cls.workflow_module = importlib.import_module('controller.workflow')
+
+    def make_client(self, graph_response):
+        self.workflow_module.workFlowModel = FakeWorkFlowModel(graph_response)
+        app = Flask(__name__)
+        app.register_blueprint(self.workflow_module.workFlow, url_prefix='/workflow')
+        return app.test_client()
+
+    def test_missing_workflow_returns_404_for_none(self):
+        client = self.make_client(None)
+        response = client.get('/workflow/missing-id')
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.get_data(as_text=True), 'Not Found')
+
+    def test_missing_workflow_returns_404_for_legacy_tuple(self):
+        client = self.make_client((False, 'Record Not Found'))
+        response = client.get('/workflow/missing-id')
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.get_data(as_text=True), 'Not Found')
+
+    def test_hash_header_returns_400_for_different_history(self):
+        client = self.make_client(VALID_GRAPHML)
+        response = client.get('/workflow/existing-id', headers={'X-Latest-Hash': 'unknown-hash'})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_data(as_text=True), 'Different History')
+
+    def test_hash_header_returns_200_for_matching_history(self):
+        client = self.make_client(VALID_GRAPHML)
+        response = client.get('/workflow/existing-id', headers={'X-Latest-Hash': 'hash-1'})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_data(as_text=True), VALID_GRAPHML)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #323 
## Problem
`GET /workflow/<serverID>` could miss the intended `404 Not Found` path because model and controller used different not-found contracts:
- `WorkFlowModel.get()` could return `(False, 'Record Not Found')`
- `getWorkflow()` checked only for `None`

This mismatch could lead to invalid downstream behavior instead of a clean 404.

## Root Cause
Inconsistent API contract between:
- `server/model/workflows.py`
- `server/controller/workflow.py`

## Changes
1. Standardized model contract:
- `WorkFlowModel.get()` now returns `None` when `serverID` is missing.

2. Hardened controller handling:
- Added `isMissingWorkflow(...)` guard in `server/controller/workflow.py`.
- Guard handles both:
  - new contract: `None`
  - legacy contract: `(False, 'Record Not Found')`
- Ensures `GET /workflow/<serverID>` consistently returns `404` for missing workflows.

3. Added regression tests:
- New file: `server/tests/test_workflow_controller.py`
- Covers:
  - missing workflow (`None`) -> `404`
  - missing workflow (legacy tuple) -> `404`
  - hash mismatch with `X-Latest-Hash` -> `400`
  - hash match with `X-Latest-Hash` -> `200`

## Files Changed
- `server/model/workflows.py`
- `server/controller/workflow.py`
- `server/tests/test_workflow_controller.py`

## Behavior After This PR
- `GET /workflow/<missing-id>` always returns `404 Not Found`
- Behavior is consistent with and without `X-Latest-Hash`
- Legacy not-found return shape is still safely handled in controller

## Validation
- Syntax check passed:
  - `python -m py_compile server/controller/workflow.py server/model/workflows.py server/tests/test_workflow_controller.py`
- Ran backend regression tests locally(from `server/`):
  - `python -m unittest discover -s tests -p "test_*.py" -v`
- Result: `Ran 4 tests ... OK`
### Test Output Screenshot
<img width="1464" height="338" alt="Screenshot 2026-02-20 032147" src="https://github.com/user-attachments/assets/43f1bd62-d81a-4a57-ad3b-03829da85814" />
 

## Notes
This is backward-compatible at controller level while moving model behavior to a single clear not-found contract.

