### PR TITLE
fix: add null guard to redo() to match undo() pattern

### DIFF
--- a/src/toolbarActions/toolbarFunctions.js
+++ b/src/toolbarActions/toolbarFunctions.js
@@ -175,7 +175,7 @@ const undo = (state) => {
     if (getGraphFun(state)) getGraphFun(state).undo();
 };
 const redo = (state) => {
-    getGraphFun(state).redo();
+    if (getGraphFun(state)) getGraphFun(state).redo();
 };
 
 const openShareModal = (state, setState) => {


### PR DESCRIPTION
fixes #327

redo() was calling getGraphFun(state).redo() without checking if the graph exists first, while undo() right above it has the guard. will crash if you try to redo when no graph is loaded

just copied the same if check from undo() to keep them consistent.