### PR TITLE
fix: check response.ok in write methods, drop Promise wrapper

### DIFF
--- a/src/serverCon/crud_http.js
+++ b/src/serverCon/crud_http.js
@@ -1,66 +1,56 @@
 import ec from './config';
 
 function getGraph(serverID) {
-    return new Promise((resolve, reject) => {
-        fetch(`${ec.baseURL + ec.getGraph(serverID)}`).then((x) => {
-            resolve(x.text());
-        }).catch((e) => reject(e));
-    });
+    return fetch(`${ec.baseURL + ec.getGraph(serverID)}`).then((x) => x.text());
 }
 
 function getGraphWithHashCheck(serverID, latestHash) {
-    return new Promise((resolve, reject) => {
-        fetch(`${ec.baseURL + ec.getGraph(serverID)}`, {
-            headers: {
-                'X-Latest-Hash': latestHash,
-            },
-        }).then((x) => {
-            if (x.status === 200) resolve(x.text());
-            else reject(x.text());
-        }).catch((e) => reject(e));
+    return fetch(`${ec.baseURL + ec.getGraph(serverID)}`, {
+        headers: {
+            'X-Latest-Hash': latestHash,
+        },
+    }).then((x) => {
+        if (x.status === 200) return x.text();
+        return Promise.reject(x.text());
     });
 }
 
 function postGraph(graphml) {
-    return new Promise((resolve, reject) => {
-        fetch(`${ec.baseURL + ec.postGraph}/`, {
-            headers: {
-                'Content-Type': 'application/xml',
-            },
-            method: 'POST',
-            body: graphml,
-
-        }).then((x) => {
-            resolve(x.text());
-        }).catch((e) => reject(e));
+    return fetch(`${ec.baseURL + ec.postGraph}/`, {
+        headers: {
+            'Content-Type': 'application/xml',
+        },
+        method: 'POST',
+        body: graphml,
+    }).then((x) => {
+        if (!x.ok) return Promise.reject(x.text());
+        return x.text();
     });
 }
 
 function updateGraph(serverID, graphml) {
-    return new Promise((resolve, reject) => {
-        fetch(ec.baseURL + ec.updateGraph(serverID), {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/xml',
-            },
-            body: graphml,
-        }).then((x) => {
-            resolve(x.text());
-        }).catch((e) => reject(e));
+    return fetch(ec.baseURL + ec.updateGraph(serverID), {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/xml',
+        },
+        body: graphml,
+    }).then((x) => {
+        if (!x.ok) return Promise.reject(x.text());
+        return x.text();
     });
 }
 
 function forceUpdateGraph(serverID, graphml) {
-    return new Promise((resolve, reject) => {
-        fetch(ec.baseURL + ec.forceUpdateGraph(serverID), {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/xml',
-            },
-            body: graphml,
-        }).then((x) => {
-            resolve(x.text());
-        }).catch((e) => reject(e));
+    return fetch(ec.baseURL + ec.forceUpdateGraph(serverID), {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/xml',
+        },
+        body: graphml,
+    }).then((x) => {
+        if (!x.ok) return Promise.reject(x.text());
+        return x.text();
     });
 }
 


### PR DESCRIPTION
Fixes #302

[postGraph](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [updateGraph](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and [forceUpdateGraph](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) were resolving on any HTTP response, so a 4xx/5xx from the server looked like a success to the rest of the app. Added a [response.ok](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) check to each so they reject on error, same as [getGraphWithHashCheck](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) already does. Also removed the [new Promise()](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) wrapper from all four functions since fetch already returns a promise and the wrapper was swallowing network errors