### PR TITLE
fix: replace eval() with new Function() in setEdgeNodeValidator to pr…

### DIFF
--- a/src/graph-builder/graph-core/3-component.js
+++ b/src/graph-builder/graph-core/3-component.js
@@ -234,10 +234,10 @@ class GraphComponent extends GraphCanvas {
     }
 
     setEdgeNodeValidator({ nodeValidator, edgeValidator }) {
-        // eslint-disable-next-line no-eval
-        this.nodeValidator = eval(nodeValidator);
-        // eslint-disable-next-line no-eval
-        this.edgeValidator = eval(edgeValidator);
+        // eslint-disable-next-line no-new-func
+        this.nodeValidator = new Function(`return ${nodeValidator}`)();
+        // eslint-disable-next-line no-new-func
+        this.edgeValidator = new Function(`return ${edgeValidator}`)();
     }
 
     getNodesEdges() {


### PR DESCRIPTION
Closes #307

[setEdgeNodeValidator](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) was calling eval() directly on user-supplied validator strings, which meant anyone sharing a graph with a malicious validator could run arbitrary JS in the victim's browser. Swapped to [new Function()](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) which keeps the execution out of the local scope no access to this, imports, or closure variables.