### PR TITLE
fix: SET_FUNCTIONS was mutating the graph object in-place

### DIFF
--- a/src/reducer/reducer.js
+++ b/src/reducer/reducer.js
@@ -234,12 +234,17 @@ const reducer = (state, action) => {
 
     case T.SET_FUNCTIONS: {
         const newState = { ...state };
-        newState.graphs[state.curGraphIndex].built = action.payload.built;
-        newState.graphs[state.curGraphIndex].debugged = action.payload.debugged;
-        newState.graphs[state.curGraphIndex].ran = action.payload.ran;
-        newState.graphs[state.curGraphIndex].cleared = action.payload.cleared;
-        newState.graphs[state.curGraphIndex].destroyed = action.payload.destroyed;
-        newState.graphs[state.curGraphIndex].stopped = action.payload.stopped;
+        newState.graphs = newState.graphs.map((g, index) => (
+            index === state.curGraphIndex ? {
+                ...g,
+                built: action.payload.built,
+                debugged: action.payload.debugged,
+                ran: action.payload.ran,
+                cleared: action.payload.cleared,
+                destroyed: action.payload.destroyed,
+                stopped: action.payload.stopped,
+            } : g
+        ));
         return { ...newState };
     }
 


### PR DESCRIPTION
Shallow copy means [newState.graphs[curGraphIndex]](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is still the same ref, React skips the re-render, toolbar buttons don't update after server actions.

Fixed by using [.map()](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) like every other case that touches a graph ([SET_FILE_HANDLE](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [SET_AUTHOR](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), etc..

Closes #335