### PR TITLE
 Encode server action URLs safely and fix GraphArea lint return path

### DIFF
--- a/src/GraphArea.jsx
+++ b/src/GraphArea.jsx
@@ -56,11 +56,12 @@ function Graph({
     }, [active, instance, graphID, dispatcher]);
 
     useEffect(() => {
-        if (!ref.current) return;
-        setContainerDim(ref.current);
         const handleResize = () => setContainerDim(ref.current);
-        window.addEventListener('resize', handleResize);
-        setInstance(initialiseNewGraph());
+        if (ref.current) {
+            setContainerDim(ref.current);
+            window.addEventListener('resize', handleResize);
+            setInstance(initialiseNewGraph());
+        }
         return () => window.removeEventListener('resize', handleResize);
     }, [ref]);
 

--- a/src/graph-builder/graph-core/6-server.js
+++ b/src/graph-builder/graph-core/6-server.js
@@ -51,7 +51,6 @@ class GraphServer extends GraphLoadSave {
     //             this.setGraphML(graphXML);
     //         });
     //     } else {
-    //         // eslint-disable-next-line no-toast.success
     //         toast.success('Not on server');
     //     }
     // }
@@ -65,7 +64,6 @@ class GraphServer extends GraphLoadSave {
 
     //         });
     //     } else {
-    //         // eslint-disable-next-line no-toast.success
     //         toast.success('Not on server');
     //     }
     // }
@@ -119,7 +117,6 @@ class GraphServer extends GraphLoadSave {
                 toast.error(err.response?.data?.message || err.message);
             });
         } else {
-            // eslint-disable-next-line no-toast.success
             toast.success('Not on server');
         }
     }
@@ -133,7 +130,6 @@ class GraphServer extends GraphLoadSave {
 
             });
         } else {
-            // eslint-disable-next-line no-toast.success
             toast.success('Not on server');
         }
     }

--- a/src/graph-builder/graph-core/6-server.js
+++ b/src/graph-builder/graph-core/6-server.js
@@ -170,12 +170,16 @@ class GraphServer extends GraphLoadSave {
     build() {
         const graphName = this.getCurrentGraphName();
         if (!graphName) return;
-        const url = `${EXECUTION_ENGINE_URL}/build/${this.superState.uploadedDirName}`
-            + `?fetch=${graphName}&unlock=${this.superState.unlockCheck}`
-            + `&docker=${this.superState.dockerCheck}`
-            + `&maxtime=${this.superState.maxTime}`
-            + `&params=${this.superState.params}`
-            + `&octave=${this.superState.octave}`;
+        const query = new URLSearchParams({
+            fetch: graphName,
+            unlock: this.superState.unlockCheck,
+            docker: this.superState.dockerCheck,
+            maxtime: this.superState.maxTime,
+            params: this.superState.params,
+            octave: this.superState.octave,
+        });
+        const url = `${EXECUTION_ENGINE_URL}/build/${encodeURIComponent(this.superState.uploadedDirName)}`
+            + `?${query.toString()}`;
         this.serverAction('post', url, {
             built: false, ran: true, debugged: true, cleared: false, stopped: false, destroyed: true,
         }, (res) => {
@@ -186,7 +190,7 @@ class GraphServer extends GraphLoadSave {
     debug() {
         const graphName = this.getCurrentGraphName();
         if (!graphName) return;
-        const url = `${EXECUTION_ENGINE_URL}/debug/${graphName}`;
+        const url = `${EXECUTION_ENGINE_URL}/debug/${encodeURIComponent(graphName)}`;
         this.serverAction('post', url, {
             built: false, ran: false, debugged: false, cleared: true, stopped: true, destroyed: true,
         });
@@ -195,7 +199,7 @@ class GraphServer extends GraphLoadSave {
     run() {
         const graphName = this.getCurrentGraphName();
         if (!graphName) return;
-        const url = `${EXECUTION_ENGINE_URL}/run/${graphName}`;
+        const url = `${EXECUTION_ENGINE_URL}/run/${encodeURIComponent(graphName)}`;
         this.serverAction('post', url, {
             built: false, ran: false, debugged: false, cleared: true, stopped: true, destroyed: true,
         });
@@ -204,10 +208,13 @@ class GraphServer extends GraphLoadSave {
     clear() {
         const graphName = this.getCurrentGraphName();
         if (!graphName) return;
-        const url = `${EXECUTION_ENGINE_URL}/clear/${graphName}`
-            + `?unlock=${this.superState.unlockCheck}`
-            + `&maxtime=${this.superState.maxTime}`
-            + `&params=${this.superState.params}`;
+        const query = new URLSearchParams({
+            unlock: this.superState.unlockCheck,
+            maxtime: this.superState.maxTime,
+            params: this.superState.params,
+        });
+        const url = `${EXECUTION_ENGINE_URL}/clear/${encodeURIComponent(graphName)}`
+            + `?${query.toString()}`;
         this.serverAction('post', url, {
             built: false, ran: true, debugged: true, cleared: false, stopped: true, destroyed: true,
         });
@@ -216,7 +223,7 @@ class GraphServer extends GraphLoadSave {
     stop() {
         const graphName = this.getCurrentGraphName();
         if (!graphName) return;
-        const url = `${EXECUTION_ENGINE_URL}/stop/${graphName}`;
+        const url = `${EXECUTION_ENGINE_URL}/stop/${encodeURIComponent(graphName)}`;
         this.serverAction('post', url, {
             built: false, ran: false, debugged: false, cleared: true, stopped: false, destroyed: true,
         });
@@ -225,15 +232,19 @@ class GraphServer extends GraphLoadSave {
     destroy() {
         const graphName = this.getCurrentGraphName();
         if (!graphName) return;
-        const url = `${EXECUTION_ENGINE_URL}/destroy/${graphName}`;
+        const url = `${EXECUTION_ENGINE_URL}/destroy/${encodeURIComponent(graphName)}`;
         this.serverAction('delete', url, {
             built: true, ran: false, debugged: false, cleared: false, stopped: false, destroyed: false,
         });
     }
 
     library(fileName) {
-        const url = `${EXECUTION_ENGINE_URL}/library/${this.superState.uploadedDirName}`
-            + `?filename=${fileName}&path=${this.superState.library}`;
+        const query = new URLSearchParams({
+            filename: fileName,
+            path: this.superState.library,
+        });
+        const url = `${EXECUTION_ENGINE_URL}/library/${encodeURIComponent(this.superState.uploadedDirName)}`
+            + `?${query.toString()}`;
         this.serverAction('post', url, null);
     }
 


### PR DESCRIPTION
Hi @pradeeban , Fixes #339 

This PR makes our server action requests much more robust by properly encoding dynamic URL segments and query parameters. It also includes a tiny linting fix to keep the build perfectly green.

### What was the problem?
Previously, server action URLs were built using raw string concatenation. This meant that if a user had spaces, `&`, `?`, or newlines in their workflow, folder, or library names, it would result in malformed requests that could break the application. 

### How i fixed it
* **`6-server.js` (The core fix):**
  * i Switched to `URLSearchParams` to safely build query strings for the `build()`, `clear()`, and `library()` actions.
  * Wrapped dynamic path segments in `encodeURIComponent()` across the board (`build`, `debug`, `run`, `clear`, `stop`, `destroy`, and `library`).
  * Note: The existing guard behavior for a missing `fileName` (`getCurrentGraphName()` path) was preserved exactly as is.
  
* **`GraphArea.jsx` (Linting cleanup):**
  * Fixed a `useEffect` return path to satisfy the `consistent-return` lint rule (ensuring the cleanup function always returns). There is absolutely no change to runtime behavior here; it just keeps the linter happy!

### Validation
*  **Manual UI Testing:** Verified via the DevTools Network tab that spaces, newlines, and special characters are now properly encoded in the outgoing requests.
*  **Build:** `npm run build` completes successfully with these changes.

Let me know if you'd like any adjustments
Thanks!