### PR TITLE
fix: dispose cy instance and autosave timer on tab close 

### DIFF
--- a/src/GraphArea.jsx
+++ b/src/GraphArea.jsx
@@ -57,12 +57,17 @@ function Graph({
 
     useEffect(() => {
         const handleResize = () => setContainerDim(ref.current);
+        let graph = null;
         if (ref.current) {
             setContainerDim(ref.current);
             window.addEventListener('resize', handleResize);
-            setInstance(initialiseNewGraph());
+            graph = initialiseNewGraph();
+            setInstance(graph);
         }
-        return () => window.removeEventListener('resize', handleResize);
+        return () => {
+            window.removeEventListener('resize', handleResize);
+            if (graph) graph.dispose();
+        };
     }, [ref]);
 
     // Update theme when darkMode changes

--- a/src/component/TabBar.jsx
+++ b/src/component/TabBar.jsx
@@ -15,7 +15,9 @@ const TabBar = ({ superState, dispatcher }) => {
     const [tabToClose, setTabToClose] = useState(null);
 
     const closeTab = (i) => {
-        localStorageManager.remove(superState.graphs[i] ? superState.graphs[i].graphID : null);
+        const graph = superState.graphs[i];
+        if (graph && graph.instance) graph.instance.dispose();
+        localStorageManager.remove(graph ? graph.graphID : null);
         dispatcher({ type: T.REMOVE_GRAPH, payload: i });
         if (!superState.curGraphIndex && superState.graphs.length === 1) {
             dispatcher({ type: T.SET_CUR_INSTANCE, payload: null });

--- a/src/graph-builder/graph-core/1-core.js
+++ b/src/graph-builder/graph-core/1-core.js
@@ -372,6 +372,15 @@ class CoreGraph {
         }
     }
 
+    dispose() {
+        if (!this.cy) return;
+        if (this.autoSaveIntervalId !== null) clearTimeout(this.autoSaveIntervalId);
+        this.autoSaveIntervalId = null;
+        this.cy.destroy();
+        this.cy = null;
+        this.dispatcher = null;
+    }
+
     reset() {
         this.resetAllComp();
         this.resetAllAction();


### PR DESCRIPTION
Closes #338

Added [dispose()](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to [CoreGraph](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [1-core.js](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) which calls [cy.destroy()](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), clears the pending autosave [setTimeout](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and nulls out [cy](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [dispatcher](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html). Wired it into the [useEffect](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) cleanup in [GraphArea.jsx](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and at the top of [closeTab()](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [TabBar.jsx](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) so it fires both on unmount and on explicit tab close.

Without this, every closed tab left a full cytoscape instance (canvas + WebGL context), the Konva stage, edgehandles state, and a live [setTimeout](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) all sitting in memory. Open 10 tabs, close them, heap grows forever.
