### PR TITLE
fix: Persist Options modal state to prevent configuration loss

### DIFF
--- a/src/component/modals/OptionsModal.jsx
+++ b/src/component/modals/OptionsModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import ParentModal from './ParentModal';
 import { actionType as T } from '../../reducer';
 import './optionsModal.css';
@@ -10,6 +10,25 @@ const OptionsModal = ({ superState, dispatcher }) => {
     const [param, setParam] = useState('');
     const [maxT, setmaxT] = useState('');
     const [library, setLibrary] = useState('');
+
+    useEffect(() => {
+        if (!superState.optionsModal) return;
+        setUnlock(Boolean(superState.unlockCheck));
+        setDocker(Boolean(superState.dockerCheck));
+        setOctave(Boolean(superState.octave));
+        setParam(superState.params || '');
+        setmaxT(superState.maxTime || '');
+        setLibrary(superState.library || '');
+    }, [
+        superState.optionsModal,
+        superState.unlockCheck,
+        superState.dockerCheck,
+        superState.octave,
+        superState.params,
+        superState.maxTime,
+        superState.library,
+    ]);
+
     const close = () => {
         dispatcher({ type: T.SET_OPTIONS_MODAL, payload: false });
         dispatcher(


### PR DESCRIPTION
Fixes #350 
This PR ensures the Options modal preserves user configurations by syncing form fields with the superState upon opening. It prevents the previous behavior where simply viewing settings would silently reset them to hardcoded defaults.

### **Changes**

- Hydration Logic: Added a `useEffect` hook in `OptionsModal.jsx` to populate local state from current application values.
- Synced Fields: unlock, docker, octave, params, maxTime, and library now correctly persist.

made sure that the npm run build is passing ,changes are only isolated to `OptionsModal.jsx`.
