### PR TITLE
fix: cap undo history, fix btoa unicode crash, add quota fallback (#352)

### DIFF
--- a/src/graph-builder/graph-core/4-undo-redo.js
+++ b/src/graph-builder/graph-core/4-undo-redo.js
@@ -99,6 +99,13 @@ class GraphUndoRedo extends GraphComponent {
             ),
         });
         this.curActionIndex += 1;
+
+        if (this.actionArr.length > 100) {
+            const drop = this.actionArr.length - 100;
+            this.actionArr.splice(0, drop);
+            this.curActionIndex -= drop;
+        }
+
         this.informUI();
     }
 

--- a/src/graph-builder/graph-core/5-load-save.js
+++ b/src/graph-builder/graph-core/5-load-save.js
@@ -48,11 +48,15 @@ class GraphLoadSave extends GraphUndoRedo {
     }
 
     static stringifyAction({ actionName, parameters }) {
-        return { actionName, parameters: window.btoa(JSON.stringify(parameters)) };
+        return { actionName, parameters: JSON.stringify(parameters) };
     }
 
     static parseAction({ actionName, parameters }) {
-        return { actionName, parameters: JSON.parse(window.atob(parameters)) };
+        try {
+            return { actionName, parameters: JSON.parse(parameters) };
+        } catch {
+            return { actionName, parameters: JSON.parse(window.atob(parameters)) };
+        }
     }
 
     jsonifyGraph() {

--- a/src/graph-builder/local-storage-manager.js
+++ b/src/graph-builder/local-storage-manager.js
@@ -12,8 +12,10 @@ const localStorageGet = (key) => {
 const localStorageSet = (key, value) => {
     try {
         window.localStorage.setItem(key, value);
+        return true;
     } catch (e) {
         toast.error(e.message);
+        return false;
     }
 };
 
@@ -53,12 +55,18 @@ const localStorageManager = {
     get(id) {
         const raw = localStorageGet(id);
         if (raw === null) return null;
-        return JSON.parse(window.atob(raw));
+        try {
+            return JSON.parse(raw);
+        } catch {
+            return JSON.parse(window.atob(raw));
+        }
     },
     save(id, graphContent) {
         this.addGraph(id);
-        const serializedJson = JSON.stringify(graphContent);
-        localStorageSet(id, window.btoa(serializedJson));
+        if (!localStorageSet(id, JSON.stringify(graphContent))) {
+            const stripped = { ...graphContent, actionHistory: [] };
+            localStorageSet(id, JSON.stringify(stripped));
+        }
     },
     remove(id) {
         if (this.allgs.delete(id)) this.saveAllgs();


### PR DESCRIPTION
Fixes #352

1. [actionArr](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) was never pruned, capped at 100 entries, trims from the front
2. [btoa()](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) crashes on unicode node names , switched [stringifyAction](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to plain [JSON.stringify](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [parseAction](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) falls back to [atob](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for old saved data
3. localStorage quota exceeded silently killed the graph, [save()](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now retries without [actionHistory](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) if the first write fails