### PR TITLE
fix: modal escape key, timer race, scroll lock 

### DIFF
--- a/src/component/modals/ParentModal.jsx
+++ b/src/component/modals/ParentModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import ReactModal from 'react-modal';
 import './parent-modal.css';
 
@@ -9,23 +9,26 @@ const Modal = ({
 }) => {
     const [curClass, setCurClass] = useState('');
     const [isOpen, setIsOpen] = useState(ModelOpen);
-    const [stid, setStid] = useState(null);
+    const stid = useRef(null);
     useEffect(() => {
         if (ModelOpen === true) {
             setIsOpen(true);
             setCurClass('closing');
-            clearTimeout(stid);
-            setStid(setTimeout(() => {
+            clearTimeout(stid.current);
+            document.body.style.overflow = 'hidden';
+            stid.current = setTimeout(() => {
                 setIsOpen(true);
                 setCurClass('');
-            }, 20));
+            }, 20);
         } else {
             setCurClass('closing');
-            clearTimeout(stid);
-            setStid(setTimeout(() => {
+            clearTimeout(stid.current);
+            document.body.style.overflow = '';
+            stid.current = setTimeout(() => {
                 setIsOpen(false);
-            }, 400));
+            }, 400);
         }
+        return () => clearTimeout(stid.current);
     }, [ModelOpen]);
 
     if (!isOpen) return '';
@@ -33,7 +36,7 @@ const Modal = ({
         <ReactModal
             isOpen={isOpen}
             contentLabel="onRequestClose Example"
-            // onRequestClose={closeModal} // prevent modal from closing when clicked outside
+            onRequestClose={closeModal}
             className="Modal"
             overlayClassName={`Overlay ${curClass}`}
         >


### PR DESCRIPTION
[onRequestClose](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) was commented out so Escape never worked. Switched the setTimeout ID from [useState](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to [useRef](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) so [clearTimeout](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) actually gets the right ID on fast open/close. Added [body.overflow](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) hidden/restore so the page doesn't scroll behind the overlay. 

Also Cleanup return added to the effect so the timer doesn't fire on unmount.

Fixes #362