### PR TITLE
fix: dark mode actually works now

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,13 +32,13 @@ const app = () => {
         };
     }, []);
 
-    // Update document theme attribute when darkMode changes
     useEffect(() => {
         if (superState.darkMode) {
             document.documentElement.setAttribute('data-theme', 'dark');
         } else {
             document.documentElement.removeAttribute('data-theme');
         }
+        localStorage.setItem('darkMode', superState.darkMode);
     }, [superState.darkMode]);
 
     return (

--- a/src/component/Header.jsx
+++ b/src/component/Header.jsx
@@ -52,18 +52,7 @@ const Header = ({ superState, dispatcher }) => {
                 </section>
                 <div
                     onClick={() => dispatcher({ type: T.TOGGLE_DARK_MODE })}
-                    style={{
-                        cursor: 'pointer',
-                        border: '1px solid #ccc',
-                        padding: '0 8px',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        transition: 'opacity 0.2s',
-                        backgroundColor: '#eee',
-                    }}
-                    onMouseEnter={(e) => { e.currentTarget.style.opacity = '0.7'; }}
-                    onMouseLeave={(e) => { e.currentTarget.style.opacity = '1'; }}
+                    className="theme-toggle"
                     role="button"
                     tabIndex={0}
                     onKeyDown={(e) => e.key === 'Enter' && dispatcher({ type: T.TOGGLE_DARK_MODE })}

--- a/src/component/codeEdit.css
+++ b/src/component/codeEdit.css
@@ -36,3 +36,8 @@
     width: 100%;
     white-space: break-spaces;
 }
+
+[data-theme='dark'] .textField {
+    background-color: #2D2D2D;
+    color: #E4E4E4;
+}

--- a/src/component/header.css
+++ b/src/component/header.css
@@ -146,7 +146,31 @@
     background-color: #2B8CF7;
 }
 
+[data-theme='dark'] .theme-toggle {
+    background-color: #2D2D2D;
+    border: 1px solid #3E3E3E;
+}
+
+[data-theme='dark'] .theme-icon {
+    color: #E4E4E4;
+}
+
 /* Theme Icon Color */
 .theme-icon {
     color: black;
+}
+
+.theme-toggle {
+    cursor: pointer;
+    border: 1px solid #ccc;
+    padding: 0 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #eee;
+    transition: opacity 0.2s;
+}
+
+.theme-toggle:hover {
+    opacity: 0.7;
 }

--- a/src/reducer/initialState.js
+++ b/src/reducer/initialState.js
@@ -38,7 +38,9 @@ const initialState = {
     octave: false,
     logs: false,
     logsmessage: '',
-    darkMode: false,
+    darkMode: localStorage.getItem('darkMode') !== null
+        ? localStorage.getItem('darkMode') === 'true'
+        : window.matchMedia('(prefers-color-scheme: dark)').matches,
     clipboard: [],
     confirmModal: { open: false, message: '', onConfirm: null },
     searchPanel: false,


### PR DESCRIPTION
toggle was setting data-theme on the html element but nothing was reading it, inline hardcoded colors everywhere. also reset on every refresh with no persistence.


- moved inline styles on the toggle button to a CSS class so dark overrides can target it

- [initialState](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) reads from [localStorage](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), falls back to prefers-color-scheme

- [localStorage.setItem](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) wired into the existing theme [useEffect](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [App.jsx](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

- dark overrides for .textField in codeEdit (was pure #f5f5f5 regardless of theme)

closes  #361