### PR TITLE
fix: harden invalid graphml import handling

### DIFF
--- a/src/graph-builder/graph-core/5-load-save.js
+++ b/src/graph-builder/graph-core/5-load-save.js
@@ -231,6 +231,8 @@ class GraphLoadSave extends GraphUndoRedo {
             localStorageManager.save(this.id, graphObject);
             this.loadGraphFromLocalStorage();
             this.lastSavedActionIndex = this.curActionIndex;
+        }).catch(() => {
+            toast.error('Invalid GraphML file.');
         });
     }
 

--- a/src/graph-builder/graphml/parser/index.js
+++ b/src/graph-builder/graphml/parser/index.js
@@ -4,18 +4,26 @@ import {
     parseNode, parseEdge, parseDetails, parseActionHistory,
 } from './parseProperties';
 
-const parser = (graphMlCnt) => new Promise((resolve) => {
+const parser = (graphMlCnt) => new Promise((resolve, reject) => {
     new xml2js.Parser().parseString(graphMlCnt, (err, grahMLObj) => {
-        const grahML = new PropFromArr(grahMLObj);
-        const nodes = grahML.parseProps('graphml.graph.node', 1).map(parseNode);
-        const edges = grahML.parseProps('graphml.graph.edge', 1).map(parseEdge);
-        const {
-            id, projectName, serverID, authorName,
-        } = parseDetails(grahML);
-        const actionHistory = parseActionHistory(grahML);
-        resolve({
-            id, projectName, edges, nodes, actionHistory, serverID, authorName,
-        });
+        if (err || !grahMLObj) {
+            reject(err || new Error('Invalid GraphML file.'));
+            return;
+        }
+        try {
+            const grahML = new PropFromArr(grahMLObj);
+            const nodes = grahML.parseProps('graphml.graph.node', 1).map(parseNode);
+            const edges = grahML.parseProps('graphml.graph.edge', 1).map(parseEdge);
+            const {
+                id, projectName, serverID, authorName,
+            } = parseDetails(grahML);
+            const actionHistory = parseActionHistory(grahML);
+            resolve({
+                id, projectName, edges, nodes, actionHistory, serverID, authorName,
+            });
+        } catch {
+            reject(new Error('Invalid GraphML file.'));
+        }
     });
 });
 export default parser;

--- a/src/toolbarActions/toolbarFunctions.js
+++ b/src/toolbarActions/toolbarFunctions.js
@@ -160,6 +160,8 @@ const readFile = async (state, setState, file, fileHandle) => {
                             projectName, graphML: x.target.result, fileHandle, fileName: file.name, authorName,
                         },
                     });
+                }).catch(() => {
+                    toast.error('Invalid GraphML file.');
                 });
             };
             if (fileHandle) fr.readAsText(await fileHandle.getFile());


### PR DESCRIPTION
Fix invalid GraphML import handling
Malformed/partial GraphML was failing inconsistently and could blow up in import flow.

This patch makes import failure deterministic:


- parser now rejects on invalid XML/GraphML

- import handlers catch and show [Invalid GraphML file.](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

- applied in both toolbar import and [setGraphML()](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) path

closes #373