### PR TITLE
Auto-fill Contribute form from active graph metadata

### DIFF
--- a/src/component/modals/ContributeDetails.jsx
+++ b/src/component/modals/ContributeDetails.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { toast } from 'react-toastify';
 import axios from 'axios';
 import { EXECUTION_ENGINE_URL } from '../../serverCon/config';
@@ -10,13 +10,25 @@ const ContributeDetails = ({ superState, dispatcher }) => {
     const closeModal = () => {
         dispatcher({ type: T.SET_CONTRIBUTE_MODAL, payload: false });
     };
-    const [study, setStudy] = useState('');
-    const [path, setPath] = useState('');
-    const [auth, setAuth] = useState('');
+
+    const curGraph = superState.graphs[superState.curGraphIndex] ?? {};
+
+    const [study, setStudy] = useState(curGraph.projectName ?? '');
+    const [path, setPath] = useState(superState.uploadedDirName ?? '');
+    const [auth, setAuth] = useState(curGraph.authorName ?? '');
     const [title, setTitle] = useState('');
     const [desc, setDesc] = useState('');
     const [branch, setBranch] = useState('');
     const [showAdvanceOptions, setShowAdvanceOptions] = useState(false);
+
+    useEffect(() => {
+        if (superState.contributeModal) {
+            const activeGraph = superState.graphs[superState.curGraphIndex] ?? {};
+            setStudy(activeGraph.projectName ?? '');
+            setPath(superState.uploadedDirName ?? '');
+            setAuth(activeGraph.authorName ?? '');
+        }
+    }, [superState.contributeModal]);
     const submit = async (e) => {
         if (study === '' || path === '' || auth === '') {
             toast.info('Please Provide necessary inputs');

--- a/src/component/modals/ContributeDetails.jsx
+++ b/src/component/modals/ContributeDetails.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { toast } from 'react-toastify';
 import axios from 'axios';
 import { EXECUTION_ENGINE_URL } from '../../serverCon/config';
@@ -20,15 +20,26 @@ const ContributeDetails = ({ superState, dispatcher }) => {
     const [desc, setDesc] = useState('');
     const [branch, setBranch] = useState('');
     const [showAdvanceOptions, setShowAdvanceOptions] = useState(false);
+    const prevOpenRef = useRef(false);
 
     useEffect(() => {
-        if (superState.contributeModal) {
+        if (superState.contributeModal && !prevOpenRef.current) {
             const activeGraph = superState.graphs[superState.curGraphIndex] ?? {};
             setStudy(activeGraph.projectName ?? '');
             setPath(superState.uploadedDirName ?? '');
             setAuth(activeGraph.authorName ?? '');
+            setTitle('');
+            setDesc('');
+            setBranch('');
+            setShowAdvanceOptions(false);
         }
-    }, [superState.contributeModal]);
+        prevOpenRef.current = superState.contributeModal;
+    }, [
+        superState.contributeModal,
+        superState.graphs,
+        superState.curGraphIndex,
+        superState.uploadedDirName,
+    ]);
     const submit = async (e) => {
         if (study === '' || path === '' || auth === '') {
             toast.info('Please Provide necessary inputs');


### PR DESCRIPTION
The Contribute form previously required users to manually type their **Study Name**, **Study Path**, and **Author Name** every time even though the editor already stores all three values in state.
So, this is just a small improvement to store them in the contribute form by default (can be changed later when actually contributing).

<img width="1836" height="632" alt="image" src="https://github.com/user-attachments/assets/012db019-4191-4e92-abd9-2ea7297a0151" />

<img width="1861" height="650" alt="image" src="https://github.com/user-attachments/assets/6c32a326-7f1e-48c1-bd44-8e0339dfbdae" />
